### PR TITLE
ページネーションによるイベント一覧画面のイベント表示 & 時系列ごとにイベントを切り分けて表示する

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -6,6 +6,20 @@
         { "fieldPath": "userUid", "mode": "ASCENDING" },
         { "fieldPath": "eventDate", "mode": "DESCENDING" }
       ]
+    },
+    {
+      "collectionId": "event_attendee",
+      "fields": [
+        { "fieldPath": "userUid", "mode": "ASCENDING" },
+        { "fieldPath": "eventDate", "mode": "ASCENDING"}
+      ]
+    },
+    {
+      "collectionId": "event_attendee",
+      "fields": [
+        { "fieldPath": "host", "mode": "ASCENDING" },
+        { "fieldPath": "eventDate", "mode": "DESCENDING" }
+      ]
     }
   ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,3 +1,11 @@
 {
-  "indexes": []
+  "indexes": [
+    {
+      "collectionId": "event_attendee",
+      "fields": [
+        { "fieldPath": "userUid", "mode": "ASCENDING" },
+        { "fieldPath": "eventDate", "mode": "DESCENDING" }
+      ]
+    }
+  ]
 }

--- a/src/features/events/EventDashboard/EventDashboard.jsx
+++ b/src/features/events/EventDashboard/EventDashboard.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { firestoreConnect } from 'react-redux-firebase'
-import { Grid, Button } from 'semantic-ui-react'
+import { Grid, Loader } from 'semantic-ui-react'
 import EventList from '../EventList/EventList'
 import { getEventsForDashboard } from '../eventActions'
 import LoadingComponent from '../../../app/layout/LoadingComponent'
@@ -54,12 +54,9 @@ class EventDashboard extends Component {
     }
   }
 
-  handleDeleteEvent = eventId => () => {
-    this.props.deleteEvent(eventId)
-  }
-
   render() {
     const { loading } = this.props;
+    const { moreEvents, loadedEvents } = this.state;
 
     if (this.state.loadingInitial) return <LoadingComponent inverted={true} />
 
@@ -67,20 +64,17 @@ class EventDashboard extends Component {
       <Grid>
         <Grid.Column width={10}>
           <EventList
-            deleteEvent={this.handleDeleteEvent}
-            events={this.state.loadedEvents}
-          />
-          <Button
             loading={loading}
-            onClick={this.getNextEvents}
-            disabled={!this.state.moreEvents}
-            content='More'
-            color='green'
-            floated='right'
+            moreEvents={moreEvents}
+            events={loadedEvents}
+            getNextEvents={this.getNextEvents}
           />
         </Grid.Column>
         <Grid.Column width={6}>
           <EventActivity />
+        </Grid.Column>
+        <Grid.Column width={10}>
+          <Loader active={loading} />
         </Grid.Column>
       </Grid>
     )

--- a/src/features/events/EventDashboard/EventDashboard.jsx
+++ b/src/features/events/EventDashboard/EventDashboard.jsx
@@ -19,6 +19,8 @@ const actions = {
 class EventDashboard extends Component {
   state = {
     moreEvents: false,
+    loadingInitial: true,
+    loadedEvents: []
   }
 
   async componentDidMount() {
@@ -26,8 +28,17 @@ class EventDashboard extends Component {
 
     if (next && next.docs && next.docs.length > 1) {
       this.setState({
-        moreEvents: true
+        moreEvents: true,
+        loadingInitial: false
       });
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.events !== nextProps.events) {
+      this.setState({
+        loadedEvents: [...this.state.loadedEvents, ...nextProps.events]
+      })
     }
   }
 
@@ -48,17 +59,19 @@ class EventDashboard extends Component {
   }
 
   render() {
-    const { events, loading } = this.props;
-    if (loading) return <LoadingComponent inverted={true} />
+    const { loading } = this.props;
+
+    if (this.state.loadingInitial) return <LoadingComponent inverted={true} />
 
     return (
       <Grid>
         <Grid.Column width={10}>
           <EventList
             deleteEvent={this.handleDeleteEvent}
-            events={events}
+            events={this.state.loadedEvents}
           />
           <Button
+            loading={loading}
             onClick={this.getNextEvents}
             disabled={!this.state.moreEvents}
             content='More'

--- a/src/features/events/EventDashboard/EventDashboard.jsx
+++ b/src/features/events/EventDashboard/EventDashboard.jsx
@@ -1,28 +1,33 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { firestoreConnect, isLoaded, isEmpty } from 'react-redux-firebase'
+import { firestoreConnect } from 'react-redux-firebase'
 import { Grid } from 'semantic-ui-react'
 import EventList from '../EventList/EventList'
-import { deleteEvent } from '../eventActions'
+import { getEventsForDashboard } from '../eventActions'
 import LoadingComponent from '../../../app/layout/LoadingComponent'
 import EventActivity from '../EventActivity/EventActivity'
 
 const mapStateToProps = state => ({
-  events: state.firestore.ordered.events
+  events: state.events,
+  loading: state.async.loading
 })
 
 const actions = {
-  deleteEvent
+  getEventsForDashboard
 }
 
 class EventDashboard extends Component {
+  componentDidMount() {
+    this.props.getEventsForDashboard();
+  }
+
   handleDeleteEvent = eventId => () => {
     this.props.deleteEvent(eventId)
   }
 
   render() {
-    const { events } = this.props;
-    if (!isLoaded(events) || isEmpty(events)) return <LoadingComponent inverted={true} />
+    const { events, loading } = this.props;
+    if (loading) return <LoadingComponent inverted={true} />
 
     return (
       <Grid>

--- a/src/features/events/EventDashboard/EventDashboard.jsx
+++ b/src/features/events/EventDashboard/EventDashboard.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { firestoreConnect } from 'react-redux-firebase'
-import { Grid } from 'semantic-ui-react'
+import { Grid, Button } from 'semantic-ui-react'
 import EventList from '../EventList/EventList'
 import { getEventsForDashboard } from '../eventActions'
 import LoadingComponent from '../../../app/layout/LoadingComponent'
@@ -17,8 +17,30 @@ const actions = {
 }
 
 class EventDashboard extends Component {
-  componentDidMount() {
-    this.props.getEventsForDashboard();
+  state = {
+    moreEvents: false,
+  }
+
+  async componentDidMount() {
+    let next = await this.props.getEventsForDashboard();
+
+    if (next && next.docs && next.docs.length > 1) {
+      this.setState({
+        moreEvents: true
+      });
+    }
+  }
+
+  getNextEvents = async () => {
+    const { events } = this.props;
+    let lastEvent = events && events[events.length -1];
+    let next = await this.props.getEventsForDashboard(lastEvent);
+
+    if (next && next.docs && next.docs.length <= 1) {
+      this.setState({
+        moreEvents: false
+      });
+    }
   }
 
   handleDeleteEvent = eventId => () => {
@@ -35,6 +57,13 @@ class EventDashboard extends Component {
           <EventList
             deleteEvent={this.handleDeleteEvent}
             events={events}
+          />
+          <Button
+            onClick={this.getNextEvents}
+            disabled={!this.state.moreEvents}
+            content='More'
+            color='green'
+            floated='right'
           />
         </Grid.Column>
         <Grid.Column width={6}>

--- a/src/features/events/EventList/EventList.jsx
+++ b/src/features/events/EventList/EventList.jsx
@@ -1,19 +1,26 @@
 import React, { Component } from 'react'
 import EventListItem from './EventListItem'
+import InfiniteScroll from 'react-infinite-scroller'
 
 class EventList extends Component {
   render() {
-    const { events, deleteEvent } = this.props;
+    const { events, getNextEvents, loading, moreEvents } = this.props
 
     return (
       <React.Fragment>
-        {events && events.map(event => (
-          <EventListItem
-            key={event.id}
-            event={event}
-            deleteEvent={deleteEvent}
-          />
-        ))}
+        {events && 
+          events.length !== 0 && (
+            <InfiniteScroll
+              pageStart={0}
+              loadMore={getNextEvents}
+              hasMore={!loading && moreEvents}
+              initialLoad={false}
+            >
+              {events && events.map(event => (
+                <EventListItem key={event.id} event={event} />
+              ))}
+            </InfiniteScroll>
+          )}
       </React.Fragment>
     )
   }

--- a/src/features/events/eventActions.jsx
+++ b/src/features/events/eventActions.jsx
@@ -1,16 +1,9 @@
 import { toastr } from 'react-redux-toastr'
-import { DELETE_EVENT, FETCH_EVENTS } from './eventConstants'
+import { FETCH_EVENTS } from './eventConstants'
 import { asyncActionStart, asyncActionFinish, asyncActionError } from '../async/asyncActions'
-import { fetchSampleData } from '../../app/data/mockApi'
 import { createNewEvent } from '../../app/common/util/helpers'
 import moment from 'moment'
-
-export const fetchEvents = events => {
-  return {
-    type: FETCH_EVENTS,
-    payload: events
-  }
-}
+import firebase from '../../app/config/firebase'
 
 export const createEvent = event => {
   return async (dispatch, getState, { getFirestore }) => {
@@ -67,26 +60,26 @@ export const cancelToggle = (cancelled, eventId) => async (dispatch, getState, {
   }
 }
 
-export const deleteEvent = eventId => {
-  return {
-    type: DELETE_EVENT,
-    payload: {
-      eventId
-    }
-  }
-}
+export const getEventsForDashboard = () => async (dispatch, getState) => {
+  let today = new Date(Date.now())
+  const firestore = firebase.firestore()
+  const eventsQuery = firestore.collection('events').where('date', '>=', today)
 
-export const loadEvents = () => {
-  return async dispatch => {
-    try {
-      dispatch(asyncActionStart())
-      let events = await fetchSampleData()
-      console.log(events)
-      dispatch(fetchEvents(events))
-      dispatch(asyncActionFinish())
-    } catch (error) {
-      console.log(error)
-      dispatch(asyncActionError())
+  try {
+    dispatch(asyncActionStart())
+
+    let querySnap = await eventsQuery.get()
+    let events = [];
+
+    for (let i=0; i < querySnap.docs.length; i++) {
+      let evt = {...querySnap.docs[i].data(), id: querySnap.docs[i].id}
+      events.push(evt)
     }
+    
+    dispatch({type: FETCH_EVENTS, payload: { events }})
+    dispatch(asyncActionFinish())
+  } catch (error) {
+    console.log(error)
+    dispatch(asyncActionError())
   }
 }

--- a/src/features/user/UserDetail/UserDetailEvents.jsx
+++ b/src/features/user/UserDetail/UserDetailEvents.jsx
@@ -7,11 +7,13 @@ import {
   Card,
   Image
 } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+import format from 'date-fns/format';
 
-const UserDetailEvents = () => {
+const UserDetailEvents = ({ events, eventsLoading }) => {
   return (
     <Grid.Column width={12}>
-      <Segment attached>
+      <Segment attached loading={eventsLoading}>
         <Header icon='calendar' content='Events'/>
         <Menu secondary pointing>
           <Menu.Item name='All Events' active/>
@@ -20,29 +22,20 @@ const UserDetailEvents = () => {
           <Menu.Item name='Events Hosted'/>
         </Menu>
         <Card.Group itemsPerRow={5}>
-          <Card>
-            <Image src={'/assets/categoryImages/drinks.jpg'}/>
-            <Card.Content>
-              <Card.Header textAlign='center'>
-                Event Title
-              </Card.Header>
-              <Card.Meta textAlign='center'>
-                28th March 2018 at 10:00 PM
-              </Card.Meta>
-            </Card.Content>
-          </Card>
-
-          <Card>
-            <Image src={'/assets/categoryImages/drinks.jpg'}/>
-            <Card.Content>
-              <Card.Header textAlign='center'>
-                Event Title
-              </Card.Header>
-              <Card.Meta textAlign='center'>
-                28th March 2018 at 10:00 PM
-              </Card.Meta>
-            </Card.Content>
-          </Card>
+          {events && events.map(event => (
+            <Card as={Link} to={`/event/${event.id}`} key={event.id}>
+              <Image src={`/assets/categoryImages/${event.category}.jpg`}/>
+              <Card.Content>
+                <Card.Header textAlign='center'>
+                  {event.title}
+                </Card.Header>
+                <Card.Meta textAlign='center'>
+                  <div>{format(event.date && event.date.toDate(), 'YYYY/MM/DD')}</div>
+                  <div>{format(event.date && event.date.toDate(), 'h:mm A')}</div>
+                </Card.Meta>
+              </Card.Content>
+            </Card>
+          ))}
         </Card.Group>
       </Segment>
     </Grid.Column>

--- a/src/features/user/UserDetail/UserDetailEvents.jsx
+++ b/src/features/user/UserDetail/UserDetailEvents.jsx
@@ -5,22 +5,27 @@ import {
   Header,
   Menu,
   Card,
-  Image
+  Image,
+  Tab
 } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import format from 'date-fns/format';
 
-const UserDetailEvents = ({ events, eventsLoading }) => {
+const panes = [
+  { menuItem: 'All Events', pane: { key: 'allEvents'} },
+  { menuItem: 'Past Events', pane: { key: 'pastEvents'} },
+  { menuItem: 'Future Events', pane: { key: 'futureEvents'} },
+  { menuItem: 'Hosting Events', pane: { key: 'hostingEvents'} }
+];
+
+const UserDetailEvents = ({ events, eventsLoading, changeTab }) => {
   return (
     <Grid.Column width={12}>
       <Segment attached loading={eventsLoading}>
         <Header icon='calendar' content='Events'/>
-        <Menu secondary pointing>
-          <Menu.Item name='All Events' active/>
-          <Menu.Item name='Past Events'/>
-          <Menu.Item name='Future Events'/>
-          <Menu.Item name='Events Hosted'/>
-        </Menu>
+        <Tab onTabChange={(e, data) => changeTab(e, data)} panes={panes} menu={{ secondary: true, pointing: true }} />
+        <br/>
+
         <Card.Group itemsPerRow={5}>
           {events && events.map(event => (
             <Card as={Link} to={`/event/${event.id}`} key={event.id}>

--- a/src/features/user/UserDetail/UserDetailPage.jsx
+++ b/src/features/user/UserDetail/UserDetailPage.jsx
@@ -43,6 +43,10 @@ class UserDetailedPage extends Component {
     await this.props.getUserEvents(this.props.userUid);
   }
 
+  changeTab = (e, data) => {
+    this.props.getUserEvents(this.props.userUid, data.activeIndex);
+  }
+
   render() {
     const { profile, photos, auth, match, requesting, events, eventsLoading } = this.props;
     const isCurrentUser = auth.uid === match.params.id;
@@ -57,7 +61,7 @@ class UserDetailedPage extends Component {
         <UserDetailDescription profile={profile} />
         {photos && photos.length > 0 &&
         <UserDetailPhotos photos={photos} />}
-        <UserDetailEvents events={events} eventsLoading={eventsLoading} />
+        <UserDetailEvents events={events} eventsLoading={eventsLoading} changeTab={this.changeTab} />
       </Grid>
     );
   }

--- a/src/features/user/UserDetail/UserDetailPage.jsx
+++ b/src/features/user/UserDetail/UserDetailPage.jsx
@@ -26,6 +26,8 @@ const mapStateToProps = (state, ownProps) => {
   return {
     profile,
     userUid,
+    events: state.events,
+    eventsLoading: state.async.loading,
     auth: state.firebase.auth,
     photos: state.firestore.ordered.photos,
     requesting: state.firestore.status.requesting
@@ -43,7 +45,7 @@ class UserDetailedPage extends Component {
   }
 
   render() {
-    const { profile, photos, auth, match, requesting } = this.props;
+    const { profile, photos, auth, match, requesting, events, eventsLoading } = this.props;
     const isCurrentUser = auth.uid === match.params.id;
     const loading = Object.values(requesting).some(a => a === true);
 
@@ -56,7 +58,7 @@ class UserDetailedPage extends Component {
         <UserDetailDescription profile={profile} />
         {photos && photos.length > 0 &&
         <UserDetailPhotos photos={photos} />}
-        <UserDetailEvents />
+        <UserDetailEvents events={events} eventsLoading={eventsLoading} />
       </Grid>
     );
   }

--- a/src/features/user/UserDetail/UserDetailPage.jsx
+++ b/src/features/user/UserDetail/UserDetailPage.jsx
@@ -40,8 +40,7 @@ const actions = {
 
 class UserDetailedPage extends Component {
   async componentDidMount() {
-    let events = await this.props.getUserEvents(this.props.userUid);
-    console.log(events);
+    await this.props.getUserEvents(this.props.userUid);
   }
 
   render() {

--- a/src/features/user/UserDetail/UserDetailPage.jsx
+++ b/src/features/user/UserDetail/UserDetailPage.jsx
@@ -10,6 +10,7 @@ import UserDetailSidebar from './UserDetailSidebar';
 import UserDetailEvents from './UserDetailEvents';
 import { userDetailquery } from '../userQueries';
 import LoadingComponent from '../../../app/layout/LoadingComponent';
+import { getUserEvents } from '../userActions';
 
 const mapStateToProps = (state, ownProps) => {
   let userUid = null;
@@ -31,7 +32,16 @@ const mapStateToProps = (state, ownProps) => {
   }
 };
 
+const actions = {
+  getUserEvents
+}
+
 class UserDetailedPage extends Component {
+  async componentDidMount() {
+    let events = await this.props.getUserEvents(this.props.userUid);
+    console.log(events);
+  }
+
   render() {
     const { profile, photos, auth, match, requesting } = this.props;
     const isCurrentUser = auth.uid === match.params.id;
@@ -53,6 +63,6 @@ class UserDetailedPage extends Component {
 }
 
 export default compose(
-  connect(mapStateToProps),
+  connect(mapStateToProps, actions),
   firestoreConnect((auth, userUid) => userDetailquery(auth, userUid))
 )(UserDetailedPage);

--- a/src/features/user/userActions.jsx
+++ b/src/features/user/userActions.jsx
@@ -158,7 +158,7 @@ export const getUserEvents = (userUid, activeTab) => async (dispatch, getState) 
       query = eventsRef
         .where('userUid', '==', userUid)
         .where('eventDate', '<=', today)
-        .orderBy('eventDate');
+        .orderBy('eventDate', 'desc');
       break;
     case 2: // future events
       query = eventsRef
@@ -170,7 +170,7 @@ export const getUserEvents = (userUid, activeTab) => async (dispatch, getState) 
       query = eventsRef
         .where('userUid', '==', userUid)
         .where('host', '==', true)
-        .orderBy('eventDate, desc');
+        .orderBy('eventDate', 'desc');
       break;
     default:
       query = eventsRef

--- a/src/features/user/userActions.jsx
+++ b/src/features/user/userActions.jsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import cuid from 'cuid';
 import { toastr } from 'react-redux-toastr';
+import { FETCH_EVENTS } from '../events/eventConstants';
 import { asyncActionStart, asyncActionFinish, asyncActionError } from '../async/asyncActions';
 import firebase from '../../app/config/firebase';
 
@@ -180,8 +181,15 @@ export const getUserEvents = (userUid, activeTab) => async (dispatch, getState) 
 
   try {
     let querySnap = await query.get();
+    let events =[];
 
-    console.log(querySnap);
+    for (let i = 0; i < querySnap.docs.length; i++) {
+      let evt = await firestore.collection('events').doc(querySnap.docs[i].data().eventId).get();
+      events.push({...evt.data(), id: evt.id});
+    }
+
+    dispatch({type: FETCH_EVENTS, payload: { events }});
+
     dispatch(asyncActionFinish());
   } catch (error) {
     console.log(error);

--- a/src/features/user/userActions.jsx
+++ b/src/features/user/userActions.jsx
@@ -2,6 +2,7 @@ import moment from 'moment';
 import cuid from 'cuid';
 import { toastr } from 'react-redux-toastr';
 import { asyncActionStart, asyncActionFinish, asyncActionError } from '../async/asyncActions';
+import firebase from '../../app/config/firebase';
 
 export const updateProfile = user => async (dispatch, getState, { getFirebase }) => {
   const firebase = getFirebase();
@@ -144,3 +145,46 @@ export const cancelGoingToEvent = event => async (dispatch, getState, { getFires
     toastr.error('Oops', 'Something went wrong');
   }
 }
+
+export const getUserEvents = (userUid, activeTab) => async (dispatch, getState) => {
+  dispatch(asyncActionStart());
+  const firestore = firebase.firestore();
+  const today = new Date(Date.now());
+  let eventsRef = firestore.collection('event_attendee');
+  let query;
+
+  switch (activeTab) {
+    case 1: // past events
+      query = eventsRef
+        .where('userUid', '==', userUid)
+        .where('eventDate', '<=', today)
+        .orderBy('eventDate');
+      break;
+    case 2: // future events
+      query = eventsRef
+        .where('userUid', '==', userUid)
+        .where('eventDate', '>=', today)
+        .orderBy('eventDate');
+      break;
+    case 3: // hosted events
+      query = eventsRef
+        .where('userUid', '==', userUid)
+        .where('host', '==', true)
+        .orderBy('eventDate, desc');
+      break;
+    default:
+      query = eventsRef
+        .where('userUid', '==', userUid)
+        .orderBy('eventDate', 'desc');
+  }
+
+  try {
+    let querySnap = await query.get();
+
+    console.log(querySnap);
+    dispatch(asyncActionFinish());
+  } catch (error) {
+    console.log(error);
+    dispatch(asyncActionError);
+  }
+};


### PR DESCRIPTION
# やりたいこと
- イベント一覧画面で、未来の日付のイベントのみ表示する
- ページネーション機能の追加
- スクロール遷移時にイベントを読み込み表示する
- 過去、現在未来、主催のイベントでそれぞれ切り分けて表示する

# How
- Firestore のクエリ機能を使用する
- `react-infinite-scroller`で、スクロール時のイベント読み込みを行う
- 時系列ごとにイベントを取得できるよう Firestore に複合インデックスを追加する