### PR TITLE
チャット機能の追加

### DIFF
--- a/src/app/common/util/helpers.js
+++ b/src/app/common/util/helpers.js
@@ -26,3 +26,19 @@ export const createNewEvent = (user, photoURL, event) => {
     }
   }
 }
+
+// チャット用にツリー構造のオブジェクトを生成する
+export const createDataTree = dataset => {
+  let hashTable = Object.create(null);
+
+  dataset.forEach(a => hashTable[a.id] = {...a, childNodes: []});
+
+  let dataTree = [];
+
+  dataset.forEach(a => {
+    if (a.parentId) hashTable[a.parentId].childNodes.push(hashTable[a.id]);
+    else dataTree.push(hashTable[a.id]);
+  });
+
+  return dataTree;
+};

--- a/src/features/events/EventDetail/EventDetailChat.jsx
+++ b/src/features/events/EventDetail/EventDetailChat.jsx
@@ -6,18 +6,27 @@ import EventDetailChatForm from './EventDetailChatForm'
 
 class EventDetailChat extends Component {
   state = {
-    showReplyForm: false
+    showReplyForm: false,
+    selectedCommentId: null
   }
 
-  handleOpenReplyForm = () => {
+  handleOpenReplyForm = id => () => {
     this.setState({
-      showReplyForm: true
+      showReplyForm: true,
+      selectedCommentId: id
+    });
+  }
+
+  handleCloseReplyForm = () => {
+    this.setState({
+      showReplyForm: false,
+      selectedCommentId: null
     });
   }
 
   render() {
     const { addEventComment, eventId, eventChat } = this.props;
-    const { showReplyForm } = this.state;
+    const { showReplyForm, selectedCommentId } = this.state;
 
     return (
       <React.Fragment>
@@ -43,11 +52,13 @@ class EventDetailChat extends Component {
                   </Comment.Metadata>
                   <Comment.Text>{comment.text}</Comment.Text>
                   <Comment.Actions>
-                    <Comment.Action onClick={this.handleOpenReplyForm}>Reply</Comment.Action>
-                    {showReplyForm && (
+                    <Comment.Action onClick={this.handleOpenReplyForm(comment.id)}>Reply</Comment.Action>
+                    {showReplyForm && selectedCommentId === comment.id && (
                       <EventDetailChatForm
                         addEventComment={addEventComment}
                         eventId={eventId}
+                        form={`reply_${comment.id}`}
+                        closeForm={this.handleCloseReplyForm}
                       />
                     )}
                   </Comment.Actions>
@@ -55,7 +66,7 @@ class EventDetailChat extends Component {
               </Comment>
             ))}
           </Comment.Group>
-          <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} />
+          <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} form={'newComment'} />
         </Segment>
       </React.Fragment>
     );

--- a/src/features/events/EventDetail/EventDetailChat.jsx
+++ b/src/features/events/EventDetail/EventDetailChat.jsx
@@ -59,14 +59,44 @@ class EventDetailChat extends Component {
                         eventId={eventId}
                         form={`reply_${comment.id}`}
                         closeForm={this.handleCloseReplyForm}
+                        parentId={comment.id}
                       />
                     )}
                   </Comment.Actions>
                 </Comment.Content>
+
+                {comment.childNodes && comment.childNodes.map(child => (
+                  <Comment.Group>
+                    <Comment key={child.id}>
+                      <Comment.Avatar src={child.photoURL || "/assets/user.png"} />
+                      <Comment.Content>
+                        <Comment.Author as={Link} to={`/profile/${child.uid}`}>
+                          {child.displayName}
+                        </Comment.Author>
+                        <Comment.Metadata>
+                          <div>{distanceInWords(child.date, Date.now())} ago</div>
+                        </Comment.Metadata>
+                        <Comment.Text>{child.text}</Comment.Text>
+                        <Comment.Actions>
+                          <Comment.Action onClick={this.handleOpenReplyForm(child.id)}>Reply</Comment.Action>
+                          {showReplyForm && selectedCommentId === child.id && (
+                            <EventDetailChatForm
+                              addEventComment={addEventComment}
+                              eventId={eventId}
+                              form={`reply_${child.id}`}
+                              closeForm={this.handleCloseReplyForm}
+                              parentId={child.parentId}
+                            />
+                          )}
+                        </Comment.Actions>
+                      </Comment.Content>
+                    </Comment>
+                  </Comment.Group>
+                ))}
               </Comment>
             ))}
           </Comment.Group>
-          <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} form={'newComment'} />
+          <EventDetailChatForm parentId={0} addEventComment={addEventComment} eventId={eventId} form={'newComment'} />
         </Segment>
       </React.Fragment>
     );

--- a/src/features/events/EventDetail/EventDetailChat.jsx
+++ b/src/features/events/EventDetail/EventDetailChat.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Segment, Header, Comment, Form, Button } from 'semantic-ui-react'
+import { Segment, Header, Comment } from 'semantic-ui-react'
+import EventDetailChatForm from './EventDetailChatForm'
 
-const EventDetailChat = () => {
+const EventDetailChat = ({ addEventComment, eventId }) => {
   return (
     <React.Fragment>
       <Segment
@@ -29,64 +30,8 @@ const EventDetailChat = () => {
               </Comment.Actions>
             </Comment.Content>
           </Comment>
-
-          <Comment>
-            <Comment.Avatar src="/assets/user.png" />
-            <Comment.Content>
-              <Comment.Author as="a">Elliot Fu</Comment.Author>
-              <Comment.Metadata>
-                <div>Yesterday at 12:30AM</div>
-              </Comment.Metadata>
-              <Comment.Text>
-                <p>
-                  This has been very useful for my research. Thanks as well!
-                </p>
-              </Comment.Text>
-              <Comment.Actions>
-                <Comment.Action>Reply</Comment.Action>
-              </Comment.Actions>
-            </Comment.Content>
-            <Comment.Group>
-              <Comment>
-                <Comment.Avatar src="/assets/user.png" />
-                <Comment.Content>
-                  <Comment.Author as="a">Jenny Hess</Comment.Author>
-                  <Comment.Metadata>
-                    <div>Just now</div>
-                  </Comment.Metadata>
-                  <Comment.Text>Elliot you are always so right :)</Comment.Text>
-                  <Comment.Actions>
-                    <Comment.Action>Reply</Comment.Action>
-                  </Comment.Actions>
-                </Comment.Content>
-              </Comment>
-            </Comment.Group>
-          </Comment>
-
-          <Comment>
-            <Comment.Avatar src="/assets/user.png" />
-            <Comment.Content>
-              <Comment.Author as="a">Joe Henderson</Comment.Author>
-              <Comment.Metadata>
-                <div>5 days ago</div>
-              </Comment.Metadata>
-              <Comment.Text>Dude, this is awesome. Thanks so much</Comment.Text>
-              <Comment.Actions>
-                <Comment.Action>Reply</Comment.Action>
-              </Comment.Actions>
-            </Comment.Content>
-          </Comment>
-
-          <Form reply>
-            <Form.TextArea />
-            <Button
-              content="Add Reply"
-              labelPosition="left"
-              icon="edit"
-              primary
-            />
-          </Form>
         </Comment.Group>
+        <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} />
       </Segment>
     </React.Fragment>
   )

--- a/src/features/events/EventDetail/EventDetailChat.jsx
+++ b/src/features/events/EventDetail/EventDetailChat.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { Segment, Header, Comment } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+import distanceInWords from 'date-fns/distance_in_words'
 import EventDetailChatForm from './EventDetailChatForm'
 
-const EventDetailChat = ({ addEventComment, eventId }) => {
+const EventDetailChat = ({ addEventComment, eventId, eventChat }) => {
   return (
     <React.Fragment>
       <Segment
@@ -17,19 +19,21 @@ const EventDetailChat = ({ addEventComment, eventId }) => {
 
       <Segment attached>
         <Comment.Group>
-          <Comment>
-            <Comment.Avatar src="/assets/user.png" />
-            <Comment.Content>
-              <Comment.Author as="a">Matt</Comment.Author>
-              <Comment.Metadata>
-                <div>Today at 5:42PM</div>
-              </Comment.Metadata>
-              <Comment.Text>How artistic!</Comment.Text>
-              <Comment.Actions>
-                <Comment.Action>Reply</Comment.Action>
-              </Comment.Actions>
-            </Comment.Content>
-          </Comment>
+          {eventChat && eventChat.map(comment => (
+            <Comment key={comment.id}>
+              <Comment.Avatar src={comment.photoURL || "/assets/user.png"} />
+              <Comment.Content>
+                <Comment.Author as={Link} to={`/profile/${comment.uid}`}>{comment.displayName}</Comment.Author>
+                <Comment.Metadata>
+                  <div>{distanceInWords(comment.date, Date.now())} ago</div>
+                </Comment.Metadata>
+                <Comment.Text>{comment.text}</Comment.Text>
+                <Comment.Actions>
+                  <Comment.Action>Reply</Comment.Action>
+                </Comment.Actions>
+              </Comment.Content>
+            </Comment>
+          ))}
         </Comment.Group>
         <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} />
       </Segment>

--- a/src/features/events/EventDetail/EventDetailChat.jsx
+++ b/src/features/events/EventDetail/EventDetailChat.jsx
@@ -1,44 +1,65 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { Segment, Header, Comment } from 'semantic-ui-react'
 import { Link } from 'react-router-dom'
 import distanceInWords from 'date-fns/distance_in_words'
 import EventDetailChatForm from './EventDetailChatForm'
 
-const EventDetailChat = ({ addEventComment, eventId, eventChat }) => {
-  return (
-    <React.Fragment>
-      <Segment
-        textAlign="center"
-        attached="top"
-        inverted
-        color="teal"
-        style={{ border: 'none' }}
-      >
-        <Header>Chat about this event</Header>
-      </Segment>
+class EventDetailChat extends Component {
+  state = {
+    showReplyForm: false
+  }
 
-      <Segment attached>
-        <Comment.Group>
-          {eventChat && eventChat.map(comment => (
-            <Comment key={comment.id}>
-              <Comment.Avatar src={comment.photoURL || "/assets/user.png"} />
-              <Comment.Content>
-                <Comment.Author as={Link} to={`/profile/${comment.uid}`}>{comment.displayName}</Comment.Author>
-                <Comment.Metadata>
-                  <div>{distanceInWords(comment.date, Date.now())} ago</div>
-                </Comment.Metadata>
-                <Comment.Text>{comment.text}</Comment.Text>
-                <Comment.Actions>
-                  <Comment.Action>Reply</Comment.Action>
-                </Comment.Actions>
-              </Comment.Content>
-            </Comment>
-          ))}
-        </Comment.Group>
-        <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} />
-      </Segment>
-    </React.Fragment>
-  )
+  handleOpenReplyForm = () => {
+    this.setState({
+      showReplyForm: true
+    });
+  }
+
+  render() {
+    const { addEventComment, eventId, eventChat } = this.props;
+    const { showReplyForm } = this.state;
+
+    return (
+      <React.Fragment>
+        <Segment
+          textAlign="center"
+          attached="top"
+          inverted
+          color="teal"
+          style={{ border: 'none' }}
+        >
+          <Header>Chat about this event</Header>
+        </Segment>
+  
+        <Segment attached>
+          <Comment.Group>
+            {eventChat && eventChat.map(comment => (
+              <Comment key={comment.id}>
+                <Comment.Avatar src={comment.photoURL || "/assets/user.png"} />
+                <Comment.Content>
+                  <Comment.Author as={Link} to={`/profile/${comment.uid}`}>{comment.displayName}</Comment.Author>
+                  <Comment.Metadata>
+                    <div>{distanceInWords(comment.date, Date.now())} ago</div>
+                  </Comment.Metadata>
+                  <Comment.Text>{comment.text}</Comment.Text>
+                  <Comment.Actions>
+                    <Comment.Action onClick={this.handleOpenReplyForm}>Reply</Comment.Action>
+                    {showReplyForm && (
+                      <EventDetailChatForm
+                        addEventComment={addEventComment}
+                        eventId={eventId}
+                      />
+                    )}
+                  </Comment.Actions>
+                </Comment.Content>
+              </Comment>
+            ))}
+          </Comment.Group>
+          <EventDetailChatForm addEventComment={addEventComment} eventId={eventId} />
+        </Segment>
+      </React.Fragment>
+    );
+  }
 }
 
 export default EventDetailChat

--- a/src/features/events/EventDetail/EventDetailChatForm.jsx
+++ b/src/features/events/EventDetail/EventDetailChatForm.jsx
@@ -5,10 +5,13 @@ import TextArea from '../../../app/common/form/TextArea';
 
 class EventDetailChatForm extends Component {
   handleCommentSubmit = values => {
-    const { addEventComment, reset, eventId, closeForm } = this.props;
-    addEventComment(eventId, values);
+    const { addEventComment, reset, eventId, closeForm, parentId } = this.props;
+    addEventComment(eventId, values, parentId);
     reset();
-    closeForm();
+
+    if (parentId !== 0) {
+      closeForm();
+    }
   }
 
   render() {

--- a/src/features/events/EventDetail/EventDetailChatForm.jsx
+++ b/src/features/events/EventDetail/EventDetailChatForm.jsx
@@ -5,9 +5,10 @@ import TextArea from '../../../app/common/form/TextArea';
 
 class EventDetailChatForm extends Component {
   handleCommentSubmit = values => {
-    const { addEventComment, reset, eventId } = this.props;
+    const { addEventComment, reset, eventId, closeForm } = this.props;
     addEventComment(eventId, values);
     reset();
+    closeForm();
   }
 
   render() {
@@ -30,4 +31,4 @@ class EventDetailChatForm extends Component {
   }
 }
 
-export default reduxForm({ form: 'eventChat' })(EventDetailChatForm);
+export default reduxForm({ Fields: 'comment' })(EventDetailChatForm);

--- a/src/features/events/EventDetail/EventDetailChatForm.jsx
+++ b/src/features/events/EventDetail/EventDetailChatForm.jsx
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { Form, Button } from 'semantic-ui-react';
+import { Field, reduxForm } from 'redux-form';
+import TextArea from '../../../app/common/form/TextArea';
+
+class EventDetailChatForm extends Component {
+  handleCommentSubmit = values => {
+    const { addEventComment, reset, eventId } = this.props;
+    addEventComment(eventId, values);
+    reset();
+  }
+
+  render() {
+    return (
+      <Form onSubmit={this.props.handleSubmit(this.handleCommentSubmit)}>
+        <Field
+          name='comment'
+          type='text'
+          component={TextArea}
+          rows={2}
+        />
+        <Button
+          content="Add Reply"
+          labelPosition="left"
+          icon="edit"
+          primary
+        />
+      </Form>
+    )
+  }
+}
+
+export default reduxForm({ form: 'eventChat' })(EventDetailChatForm);

--- a/src/features/events/EventDetail/EventDetailPage.jsx
+++ b/src/features/events/EventDetail/EventDetailPage.jsx
@@ -7,7 +7,7 @@ import EventDetailHeader from './EventDetailHeader'
 import EventDetailInfo from './EventDetailInfo'
 import EventDetailChat from './EventDetailChat'
 import EventDetailSidebar from './EventDetailSidebar'
-import { objectToArray } from '../../../app/common/util/helpers'
+import { objectToArray, createDataTree } from '../../../app/common/util/helpers'
 import { goingToEvent, cancelGoingToEvent } from '../../user/userActions'
 import { addEventComment } from '../eventActions'
 
@@ -49,6 +49,7 @@ class EventDetailPage extends Component {
     const attendees = event && event.attendees && objectToArray(event.attendees)
     const isHost = event.hostUid === auth.uid
     const isGoing = attendees && attendees.some(a => a.id === auth.uid)
+    const chatTree = !isEmpty(eventChat) && createDataTree(eventChat)
 
     return (
       <Grid>
@@ -61,7 +62,7 @@ class EventDetailPage extends Component {
             cancelGoingToEvent={cancelGoingToEvent}
           />
           <EventDetailInfo event={event} />
-          <EventDetailChat eventChat={eventChat} addEventComment={addEventComment} eventId={event.id} />
+          <EventDetailChat eventChat={chatTree} addEventComment={addEventComment} eventId={event.id} />
         </Grid.Column>
         <Grid.Column width={6}>
           <EventDetailSidebar attendees={attendees} />

--- a/src/features/events/EventDetail/EventDetailPage.jsx
+++ b/src/features/events/EventDetail/EventDetailPage.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { withFirestore } from 'react-redux-firebase'
+import { withFirestore, firebaseConnect } from 'react-redux-firebase'
+import { compose } from 'redux'
 import { Grid } from 'semantic-ui-react'
 import EventDetailHeader from './EventDetailHeader'
 import EventDetailInfo from './EventDetailInfo'
@@ -8,6 +9,7 @@ import EventDetailChat from './EventDetailChat'
 import EventDetailSidebar from './EventDetailSidebar'
 import { objectToArray } from '../../../app/common/util/helpers'
 import { goingToEvent, cancelGoingToEvent } from '../../user/userActions'
+import { addEventComment } from '../eventActions'
 
 const mapStateToProps = state => {
   let event = {}
@@ -24,7 +26,8 @@ const mapStateToProps = state => {
 
 const actions = {
   goingToEvent,
-  cancelGoingToEvent
+  cancelGoingToEvent,
+  addEventComment
 }
 
 class EventDetailPage extends Component {
@@ -39,7 +42,7 @@ class EventDetailPage extends Component {
   }
 
   render() {
-    const { event, auth, goingToEvent, cancelGoingToEvent } = this.props
+    const { event, auth, goingToEvent, cancelGoingToEvent, addEventComment } = this.props
     const attendees = event && event.attendees && objectToArray(event.attendees)
     const isHost = event.hostUid === auth.uid
     const isGoing = attendees && attendees.some(a => a.id === auth.uid)
@@ -55,7 +58,7 @@ class EventDetailPage extends Component {
             cancelGoingToEvent={cancelGoingToEvent}
           />
           <EventDetailInfo event={event} />
-          <EventDetailChat />
+          <EventDetailChat addEventComment={addEventComment} eventId={event.id} />
         </Grid.Column>
         <Grid.Column width={6}>
           <EventDetailSidebar attendees={attendees} />
@@ -65,4 +68,8 @@ class EventDetailPage extends Component {
   }
 }
 
-export default withFirestore(connect(mapStateToProps, actions)(EventDetailPage));
+export default compose(
+  withFirestore,
+  connect(mapStateToProps, actions),
+  firebaseConnect(props => ([`event_chat/${props.match.params.id}`]))
+)(EventDetailPage)

--- a/src/features/events/EventDetail/EventDetailPage.jsx
+++ b/src/features/events/EventDetail/EventDetailPage.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { withFirestore, firebaseConnect } from 'react-redux-firebase'
+import { withFirestore, firebaseConnect, isEmpty } from 'react-redux-firebase'
 import { compose } from 'redux'
 import { Grid } from 'semantic-ui-react'
 import EventDetailHeader from './EventDetailHeader'
@@ -11,7 +11,7 @@ import { objectToArray } from '../../../app/common/util/helpers'
 import { goingToEvent, cancelGoingToEvent } from '../../user/userActions'
 import { addEventComment } from '../eventActions'
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
   let event = {}
 
   if (state.firestore.ordered.events && state.firestore.ordered.events[0]) {
@@ -20,7 +20,10 @@ const mapStateToProps = state => {
 
   return {
     event,
-    auth: state.firebase.auth
+    auth: state.firebase.auth,
+    eventChat:
+      !isEmpty(state.firebase.data.event_chat) &&
+      objectToArray(state.firebase.data.event_chat[ownProps.match.params.id])
   }
 }
 
@@ -42,7 +45,7 @@ class EventDetailPage extends Component {
   }
 
   render() {
-    const { event, auth, goingToEvent, cancelGoingToEvent, addEventComment } = this.props
+    const { event, auth, goingToEvent, cancelGoingToEvent, addEventComment, eventChat } = this.props
     const attendees = event && event.attendees && objectToArray(event.attendees)
     const isHost = event.hostUid === auth.uid
     const isGoing = attendees && attendees.some(a => a.id === auth.uid)
@@ -58,7 +61,7 @@ class EventDetailPage extends Component {
             cancelGoingToEvent={cancelGoingToEvent}
           />
           <EventDetailInfo event={event} />
-          <EventDetailChat addEventComment={addEventComment} eventId={event.id} />
+          <EventDetailChat eventChat={eventChat} addEventComment={addEventComment} eventId={event.id} />
         </Grid.Column>
         <Grid.Column width={6}>
           <EventDetailSidebar attendees={attendees} />

--- a/src/features/events/eventActions.jsx
+++ b/src/features/events/eventActions.jsx
@@ -114,11 +114,20 @@ export const getEventsForDashboard = lastEvent => async (dispatch, getState) => 
   }
 }
 
-export const addEventComment = (eventId, comment) => async (dispatch, getState, { getFirebase }) => {
+export const addEventComment = (eventId, values) => async (dispatch, getState, { getFirebase }) => {
   const firebase = getFirebase();
+  const profile = getState().firebase.profile;
+  const user = firebase.auth().currentUser;
+  let newComment = {
+    displayName: profile.displayName,
+    photoURL: profile.photoURL || '/assets/user.png',
+    uid: user.uid,
+    text: values.comment,
+    date: Date.now()
+  };
 
   try {
-    await firebase.push(`event_chat/${eventId}`, comment);
+    await firebase.push(`event_chat/${eventId}`, newComment);
   } catch (error) {
     console.log(error);
     toastr.error('Oops', error.message);

--- a/src/features/events/eventActions.jsx
+++ b/src/features/events/eventActions.jsx
@@ -113,3 +113,14 @@ export const getEventsForDashboard = lastEvent => async (dispatch, getState) => 
     dispatch(asyncActionError())
   }
 }
+
+export const addEventComment = (eventId, comment) => async (dispatch, getState, { getFirebase }) => {
+  const firebase = getFirebase();
+
+  try {
+    await firebase.push(`event_chat/${eventId}`, comment);
+  } catch (error) {
+    console.log(error);
+    toastr.error('Oops', error.message);
+  }
+}

--- a/src/features/events/eventActions.jsx
+++ b/src/features/events/eventActions.jsx
@@ -114,11 +114,12 @@ export const getEventsForDashboard = lastEvent => async (dispatch, getState) => 
   }
 }
 
-export const addEventComment = (eventId, values) => async (dispatch, getState, { getFirebase }) => {
+export const addEventComment = (eventId, values, parentId) => async (dispatch, getState, { getFirebase }) => {
   const firebase = getFirebase();
   const profile = getState().firebase.profile;
   const user = firebase.auth().currentUser;
   let newComment = {
+    parentId: parentId,
     displayName: profile.displayName,
     photoURL: profile.photoURL || '/assets/user.png',
     uid: user.uid,

--- a/src/features/user/UserDetail/UserDetailEvents.jsx
+++ b/src/features/user/UserDetail/UserDetailEvents.jsx
@@ -3,7 +3,6 @@ import {
   Grid,
   Segment,
   Header,
-  Menu,
   Card,
   Image,
   Tab


### PR DESCRIPTION
# やりたいこと
- イベント詳細ページにて、コメントを投稿できる

# How
- 返信も考慮して、コメント構造を親(元コメント)と子(元コメントに対する返信)のツリー構造で持たせる
- チャットはある程度、体感速度が求められるので、東京リージョンがある Realtime Database を使用する
- 個別のコメントにだけ返信できるよう `redux-form` の Dynamic Form を使用する