### PR TITLE
イベント作成処理やユーザー情報の更新処理をバッチ処理とトランザクション処理を使って改修

### DIFF
--- a/src/features/events/EventDetail/EventDetailHeader.jsx
+++ b/src/features/events/EventDetail/EventDetailHeader.jsx
@@ -22,7 +22,7 @@ const eventImageTextStyle = {
   color: 'white'
 };
 
-const EventDetailHeader = ({ event, isHost, isGoing, goingToEvent, cancelGoingToEvent }) => {
+const EventDetailHeader = ({ loading, event, isHost, isGoing, goingToEvent, cancelGoingToEvent }) => {
   let eventDate;
   if (event.date) {
     eventDate = event.date.toDate();
@@ -59,7 +59,7 @@ const EventDetailHeader = ({ event, isHost, isGoing, goingToEvent, cancelGoingTo
               {isGoing ? (
                 <Button onClick={() => cancelGoingToEvent(event)}>Cancel My Place</Button>
               ) : (
-                <Button onClick={() => goingToEvent(event)} color="teal">JOIN THIS EVENT</Button>
+                <Button loading={loading} onClick={() => goingToEvent(event)} color="teal">JOIN THIS EVENT</Button>
               )}
             </React.Fragment>
           }

--- a/src/features/events/EventDetail/EventDetailPage.jsx
+++ b/src/features/events/EventDetail/EventDetailPage.jsx
@@ -20,6 +20,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     event,
+    loading: state.async.loading,
     auth: state.firebase.auth,
     eventChat:
       !isEmpty(state.firebase.data.event_chat) &&
@@ -45,7 +46,7 @@ class EventDetailPage extends Component {
   }
 
   render() {
-    const { event, auth, goingToEvent, cancelGoingToEvent, addEventComment, eventChat } = this.props
+    const { loading, event, auth, goingToEvent, cancelGoingToEvent, addEventComment, eventChat } = this.props
     const attendees = event && event.attendees && objectToArray(event.attendees)
     const isHost = event.hostUid === auth.uid
     const isGoing = attendees && attendees.some(a => a.id === auth.uid)
@@ -56,6 +57,7 @@ class EventDetailPage extends Component {
         <Grid.Column width={10}>
           <EventDetailHeader
             event={event}
+            loading={loading}
             isHost={isHost}
             isGoing={isGoing}
             goingToEvent={goingToEvent}

--- a/src/features/events/EventForm/EventForm.jsx
+++ b/src/features/events/EventForm/EventForm.jsx
@@ -24,7 +24,8 @@ const mapStateToProps = state => {
 
   return {
     initialValues: event,
-    event
+    event,
+    loading: state.async.loading
   }
 }
 
@@ -99,7 +100,7 @@ class EventForm extends Component {
     }
   }
 
-  onFormSubmit = values => {
+  onFormSubmit = async values => {
     values.venueLatLng = this.state.venueLatLng
 
     if (this.props.initialValues.id) {
@@ -107,7 +108,7 @@ class EventForm extends Component {
         values.venueLatLng = this.props.event.venueLatLng
       }
 
-      this.props.updateEvent(values)
+      await this.props.updateEvent(values)
       this.props.history.goBack()
     } else {
       this.props.createEvent(values);
@@ -118,7 +119,7 @@ class EventForm extends Component {
   handleScriptLoaded = () => this.setState({scriptLoaded: true})
 
   render() {
-    const { invalid, submitting, pristine, event, cancelToggle } = this.props
+    const { loading, invalid, submitting, pristine, event, cancelToggle } = this.props
 
     return (
       <Grid>
@@ -181,10 +182,10 @@ class EventForm extends Component {
                 showTimeSelect
                 placeholder='Event Date'
               />
-              <Button disabled={invalid || submitting || pristine} positive type="submit">
+              <Button loading={loading} disabled={invalid || submitting || pristine} positive type="submit">
                 Submit
               </Button>
-              <Button type="button" onClick={this.props.history.goBack}>
+              <Button disabled={loading} type="button" onClick={this.props.history.goBack}>
                 Cancel
               </Button>
               <Button

--- a/src/features/events/eventActions.jsx
+++ b/src/features/events/eventActions.jsx
@@ -4,6 +4,7 @@ import { asyncActionStart, asyncActionFinish, asyncActionError } from '../async/
 import { createNewEvent } from '../../app/common/util/helpers'
 import moment from 'moment'
 import firebase from '../../app/config/firebase'
+import compareAsc from 'date-fns/compare_asc'
 
 export const createEvent = event => {
   return async (dispatch, getState, { getFirestore }) => {
@@ -29,17 +30,47 @@ export const createEvent = event => {
 }
 
 export const updateEvent = event => {
-  return async (dispatch, getState, { getFirestore }) => {
-    const firestore = getFirestore()
+  return async (dispatch, getState) => {
+    dispatch(asyncActionStart());
+    const firestore = firebase.firestore();
+
     if (event.date !== getState().firestore.ordered.events[0].date) {
-      event.date = moment(event.date).toDate()
+      event.date = moment(event.date).toDate();
     }
 
     try {
-      await firestore.update(`events/${event.id}`, event)
-      toastr.success('Sucess!', 'Event has been updated!')
+      let eventDocRef = firestore.collection('events').doc(event.id);
+      let dateEqual = compareAsc(getState().firestore.ordered.events[0].date.toDate(), event.date);
+
+      if (dateEqual !== 0) {
+        let batch = firestore.batch();
+
+        await batch.update(eventDocRef, event);
+
+        let eventAttendeeRef = firestore.collection('event_attendee');
+        let eventAttendeeQuery = await eventAttendeeRef.where('eventId', '==', event.id);
+        let eventAttendeeQuerySnap = await eventAttendeeQuery.get();
+
+        for (let i = 0; i < eventAttendeeQuerySnap.docs.length; i++) {
+          let eventAttendeeDocRef = await firestore
+            .collection('event_attendee')
+            .doc(eventAttendeeQuerySnap.docs[i].id);
+
+          await batch.update(eventAttendeeDocRef, {
+            eventDate: event.date
+          });
+        }
+
+        await batch.commit();
+      } else {
+        await eventDocRef.update(event);
+      }
+
+      dispatch(asyncActionFinish());
+      toastr.success('Sucess!', 'Event has been updated!');
     } catch (error) {
-      toastr.error('Oops', 'Something went wrong')
+      dispatch(asyncActionError());
+      toastr.error('Oops', 'Something went wrong');
     }
   }
 }

--- a/src/features/user/Settings/PhotosPage.jsx
+++ b/src/features/user/Settings/PhotosPage.jsx
@@ -173,8 +173,8 @@ class PhotosPage extends Component {
               <Card key={photo.id}>
                 <Image src={photo.url} />
                 <div className='ui two buttons'>
-                  <Button onClick={this.handleSetMainPhoto(photo)} basic color='green'>Main</Button>
-                  <Button onClick={this.handlePhotoDelete(photo)} basic icon='trash' color='red' />
+                  <Button loading={loading} onClick={this.handleSetMainPhoto(photo)} basic color='green'>Main</Button>
+                  <Button disabled={loading} onClick={this.handlePhotoDelete(photo)} basic icon='trash' color='red' />
                 </div>
               </Card>
           ))}

--- a/src/features/user/userActions.jsx
+++ b/src/features/user/userActions.jsx
@@ -85,15 +85,53 @@ export const deletePhoto = photo => async (dispatch, getState, { getFirebase, ge
   }
 }
 
-export const setMainPhoto = photo => async (dispatch, getState, { getFirebase }) => {
-  const firebase = getFirebase();
+export const setMainPhoto = photo => async (dispatch, getState) => {
+  dispatch(asyncActionStart());
+
+  const firestore = firebase.firestore();
+  const user = firebase.auth().currentUser;
+  const today = new Date(Date.now());
+  let userDocRef = firestore.collection('users').doc(user.uid);
+  let eventAttendeeRef = firestore.collection('event_attendee');
 
   try {
-    return await firebase.updateProfile({
+    let batch = firestore.batch();
+
+    await batch.update(userDocRef, {
       photoURL: photo.url
     });
+
+    let eventAttendeeQuery = await eventAttendeeRef
+      .where('userUid', '==', user.uid)
+      .where('eventDate', '>', today);
+
+    let eventAttendeeQuerySnap = await eventAttendeeQuery.get();
+
+    for (let i = 0; i < eventAttendeeQuerySnap.docs.length; i++) {
+      let eventDocRef = await firestore
+        .collection('events')
+        .doc(eventAttendeeQuerySnap.docs[i].data().eventId);
+
+      let event = await eventDocRef.get();
+
+      if (event.data().hostUid === user.uid) {
+        batch.update(eventDocRef, {
+          hostPhotoURL: photo.url,
+          [`attendees.${user.uid}.photoURL`]: photo.url
+        });
+      } else {
+        batch.update(eventDocRef, {
+          [`attendees.${user.uid}.photoURL`]: photo.url
+        });
+      }
+    }
+
+    console.log(batch);
+    await batch.commit();
+    dispatch(asyncActionFinish());
   } catch (error) {
     console.log(error);
+    dispatch(asyncActionError());
     throw new Error('Problem setting main photo');
   }
 }

--- a/src/features/user/userActions.jsx
+++ b/src/features/user/userActions.jsx
@@ -136,9 +136,11 @@ export const setMainPhoto = photo => async (dispatch, getState) => {
   }
 }
 
-export const goingToEvent = event => async (dispatch, getState, { getFirestore }) => {
-  const firestore = getFirestore();
-  const user = firestore.auth().currentUser;
+export const goingToEvent = event => async (dispatch, getState) => {
+  dispatch(asyncActionStart());
+
+  const firestore = firebase.firestore();
+  const user = firebase.auth().currentUser;
   const photoURL = getState().firebase.profile.photoURL || '/assets/user.png';
   const attendee = {
     going: true,
@@ -149,20 +151,27 @@ export const goingToEvent = event => async (dispatch, getState, { getFirestore }
   }
 
   try {
-    await firestore.update(`events/${event.id}`, {
-      [`attendees.${user.uid}`]: attendee
+    let eventDocRef = firestore.collection('events').doc(event.id);
+    let eventAttendeeDocRef = firestore.collection('event_attendee').doc(`${event.id}_${user.uid}`);
+
+    await firestore.runTransaction(async transaction => {
+      await transaction.get(eventDocRef);
+      await transaction.update(eventDocRef, {
+        [`attendees.${user.uid}`]: attendee
+      });
+      await transaction.set(eventAttendeeDocRef, {
+        eventId: event.id,
+        userUid: user.uid,
+        eventDate: event.date,
+        host: false
+      });
     });
 
-    await firestore.set(`event_attendee/${event.id}_${user.uid}`, {
-      eventId: event.id,
-      userUid: user.uid,
-      eventDate: event.date,
-      host: false
-    });
-
+    dispatch(asyncActionFinish());
     toastr.success('Success', 'You have signed up to the event');
   } catch (error) {
     console.log(error);
+    dispatch(asyncActionError());
     toastr.error('Oops', 'Problem signing up to event')
   }
 }


### PR DESCRIPTION
# Why

1. ユーザーのメインプロフィール画像が、変更された時に、イベントに紐づくプロフィール画像も変更を反映させたい
2. イベントの日付が変更された際、各ユーザーのイベント一覧表示の順番をソートし直したいため
3. イベント参加をするタイミングで、該当のイベント内容が、変更中の時などにデータの整合性を担保したい

# How

## 1 と2 の問題の対処法

- Firestoreのバッチ処理機能を使う

### 1 の対応の該当コミット
- https://github.com/samuraikun/meetup_sns_react_app/commit/33fb13588d7e9e714dd208ac7a9316589f981688

### 2 の対応の該当コミット
- https://github.com/samuraikun/meetup_sns_react_app/commit/a05ec1cc72f2f0eaa8b622b43e4a0f072abf3750

## 3 の問題の対処法

- Firestore のトランザクション処理機能を使う

### 3 の対応の該当コミット
- https://github.com/samuraikun/meetup_sns_react_app/commit/c895d345b9a2266557333b2cd6589273e1f82311

# 参考
- https://firebase.google.com/docs/firestore/manage-data/transactions?hl=ja