### PR TITLE
未ログインユーザー対応

### DIFF
--- a/src/app/layout/App.jsx
+++ b/src/app/layout/App.jsx
@@ -11,6 +11,7 @@ import EventDetailPage from '../../features/events/EventDetail/EventDetailPage';
 import HomePage from '../../features/home/HomePage'
 import TestComponent from '../../features/testarea/TestComponent';
 import ModalManager from '../../features/modals/ModalManager'
+import { UserIsAuthenticated } from '../../features/auth/authWrapper'
 
 class App extends Component {
   render() {
@@ -30,11 +31,11 @@ class App extends Component {
                   <Route path='/events' component={EventDashboard} />
                   <Route path='/test' component={TestComponent} />
                   <Route path='/event/:id' component={EventDetailPage} />
-                  <Route path='/manage/:id' component={EventForm} />
-                  <Route path='/people' component={PeopleDashboard} />
-                  <Route path='/profile/:id' component={UserDetailPage} />
-                  <Route path='/settings' component={SettingDashboard} />
-                  <Route path='/createEvent' component={EventForm} />
+                  <Route path='/manage/:id' component={UserIsAuthenticated(EventForm)} />
+                  <Route path='/people' component={UserIsAuthenticated(PeopleDashboard)} />
+                  <Route path='/profile/:id' component={UserIsAuthenticated(UserDetailPage)} />
+                  <Route path='/settings' component={UserIsAuthenticated(SettingDashboard)} />
+                  <Route path='/createEvent' component={UserIsAuthenticated(EventForm)} />
                 </Switch>
               </Container>
             </div>

--- a/src/features/auth/authWrapper.jsx
+++ b/src/features/auth/authWrapper.jsx
@@ -1,0 +1,12 @@
+import { connectedReduxRedirect } from 'redux-auth-wrapper/history4/redirect';
+import { openModal } from '../modals/modalActions';
+
+export const UserIsAuthenticated = connectedReduxRedirect({
+  wrapperDisplayName: 'UserInAuthenticated',
+  allowRedirectBack: true,
+  redirectPath: '/events',
+  authenticatedSelector: ({ firebase: { auth } }) => auth.isLoaded && !auth.isEmpty,
+  redirectAction: newLoc => dispatch => {
+    dispatch(openModal('UnauthModal'));
+  }
+});

--- a/src/features/events/EventDetail/EventDetailHeader.jsx
+++ b/src/features/events/EventDetail/EventDetailHeader.jsx
@@ -22,7 +22,7 @@ const eventImageTextStyle = {
   color: 'white'
 };
 
-const EventDetailHeader = ({ loading, event, isHost, isGoing, goingToEvent, cancelGoingToEvent }) => {
+const EventDetailHeader = ({ loading, event, isHost, isGoing, goingToEvent, cancelGoingToEvent, authenticated, openModal }) => {
   let eventDate;
   if (event.date) {
     eventDate = event.date.toDate();
@@ -56,17 +56,28 @@ const EventDetailHeader = ({ loading, event, isHost, isGoing, goingToEvent, canc
         <Segment attached="bottom">
           {!isHost &&
             <React.Fragment>
-              {isGoing ? (
-                <Button onClick={() => cancelGoingToEvent(event)}>Cancel My Place</Button>
-              ) : (
-                <Button loading={loading} onClick={() => goingToEvent(event)} color="teal">JOIN THIS EVENT</Button>
+              {isGoing && <Button onClick={() => cancelGoingToEvent(event)}>Cancel My Place</Button>}
+
+              {isGoing &&
+                authenticated && (
+                  <Button loading={loading} onClick={() => goingToEvent(event)} color="teal">
+                    JOIN THIS EVENT
+                  </Button>
+              )}
+
+              {!authenticated && (
+                <Button loading={loading} onClick={() => openModal('UnauthModal')} color="teal">
+                  JOIN THIS EVENT
+                </Button>
               )}
             </React.Fragment>
           }
-          {isHost &&
-          <Button as={Link} to={`/manage/${event.id}`} color="orange">
-            Manage Event
-          </Button>}
+
+          {isHost && (
+            <Button as={Link} to={`/manage/${event.id}`} color="orange">
+              Manage Event
+            </Button>
+          )}
         </Segment>
       </Segment.Group>
     </div>

--- a/src/features/events/EventDetail/EventDetailPage.jsx
+++ b/src/features/events/EventDetail/EventDetailPage.jsx
@@ -10,6 +10,7 @@ import EventDetailSidebar from './EventDetailSidebar'
 import { objectToArray, createDataTree } from '../../../app/common/util/helpers'
 import { goingToEvent, cancelGoingToEvent } from '../../user/userActions'
 import { addEventComment } from '../eventActions'
+import { openModal } from '../../modals/modalActions'
 
 const mapStateToProps = (state, ownProps) => {
   let event = {}
@@ -31,7 +32,8 @@ const mapStateToProps = (state, ownProps) => {
 const actions = {
   goingToEvent,
   cancelGoingToEvent,
-  addEventComment
+  addEventComment,
+  openModal
 }
 
 class EventDetailPage extends Component {
@@ -46,11 +48,21 @@ class EventDetailPage extends Component {
   }
 
   render() {
-    const { loading, event, auth, goingToEvent, cancelGoingToEvent, addEventComment, eventChat } = this.props
+    const {
+      openModal,
+      loading,
+      event,
+      auth,
+      goingToEvent,
+      cancelGoingToEvent,
+      addEventComment,
+      eventChat
+    } = this.props
     const attendees = event && event.attendees && objectToArray(event.attendees)
     const isHost = event.hostUid === auth.uid
     const isGoing = attendees && attendees.some(a => a.id === auth.uid)
     const chatTree = !isEmpty(eventChat) && createDataTree(eventChat)
+    const authenticated = auth.isLoaded && !auth.isEmpty;
 
     return (
       <Grid>
@@ -62,9 +74,13 @@ class EventDetailPage extends Component {
             isGoing={isGoing}
             goingToEvent={goingToEvent}
             cancelGoingToEvent={cancelGoingToEvent}
+            authenticated={authenticated}
+            openModal={openModal}
           />
           <EventDetailInfo event={event} />
-          <EventDetailChat eventChat={chatTree} addEventComment={addEventComment} eventId={event.id} />
+          {authenticated &&
+            <EventDetailChat eventChat={chatTree} addEventComment={addEventComment} eventId={event.id} />
+          }
         </Grid.Column>
         <Grid.Column width={6}>
           <EventDetailSidebar attendees={attendees} />

--- a/src/features/modals/ModalManager.jsx
+++ b/src/features/modals/ModalManager.jsx
@@ -3,11 +3,13 @@ import { connect } from 'react-redux'
 import TestModal from './TestModal'
 import LoginModal from './LoginModal'
 import RegisterModal from './RegisterModal'
+import UnauthModal from './UnauthModal'
 
 const modalLookup = {
   TestModal,
   LoginModal,
-  RegisterModal
+  RegisterModal,
+  UnauthModal
 }
 
 const mapStateToProps = state => ({

--- a/src/features/modals/UnauthModal.jsx
+++ b/src/features/modals/UnauthModal.jsx
@@ -1,20 +1,27 @@
 import React, { Component } from 'react';
 import { Modal, Button, Divider } from 'semantic-ui-react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
-import {closeModal, openModal } from './modalActions';
+import { closeModal, openModal } from './modalActions';
 
 const actions = { closeModal, openModal };
 
 class UnauthModal extends Component {
+
+  handleCloseModal = () => {
+    this.props.history.goBack();
+    this.props.closeModal();
+  }
+
   render() {
-    const { openModal, closeModal } = this.props;
+    const { openModal } = this.props;
 
     return (
       <Modal
         size='mini'
         open={true}
-        onClose={closeModal}
+        onClose={this.handleCloseModal}
       >
         <Modal.Header>
           You need to be signed in to do that!
@@ -30,7 +37,7 @@ class UnauthModal extends Component {
             <Divider/>
             <div style={{textAlign: 'center'}}>
               <p>Or click cancel to continue as a guest</p>
-              <Button onClick={closeModal}>Cancel</Button>
+              <Button onClick={this.handleCloseModal}>Cancel</Button>
             </div>
           </Modal.Description>
         </Modal.Content>
@@ -39,4 +46,4 @@ class UnauthModal extends Component {
   }
 }
 
-export default connect(null, actions)(UnauthModal);
+export default withRouter(connect(null, actions)(UnauthModal));

--- a/src/features/modals/UnauthModal.jsx
+++ b/src/features/modals/UnauthModal.jsx
@@ -10,8 +10,12 @@ const actions = { closeModal, openModal };
 class UnauthModal extends Component {
 
   handleCloseModal = () => {
-    this.props.history.goBack();
-    this.props.closeModal();
+    if (this.props.location.pathname.includes('/event')) {
+      this.props.closeModal();
+    } else {
+      this.props.history.goBack();
+      this.props.closeModal();
+    }
   }
 
   render() {

--- a/src/features/modals/UnauthModal.jsx
+++ b/src/features/modals/UnauthModal.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import { Modal, Button, Divider } from 'semantic-ui-react';
+import { connect } from 'react-redux';
+
+import {closeModal, openModal } from './modalActions';
+
+const actions = { closeModal, openModal };
+
+class UnauthModal extends Component {
+  render() {
+    const { openModal, closeModal } = this.props;
+
+    return (
+      <Modal
+        size='mini'
+        open={true}
+        onClose={closeModal}
+      >
+        <Modal.Header>
+          You need to be signed in to do that!
+        </Modal.Header>
+        <Modal.Content>
+          <Modal.Description>
+            <p>Please either login or register to see this page</p>
+            <Button.Group widths={4}>
+              <Button fluid color='teal' onClick={() => openModal("LoginModal")}>Login</Button>
+              <Button.Or />
+              <Button fluid positive onClick={() => openModal("RegisterModal")}>Register</Button>
+            </Button.Group>
+            <Divider/>
+            <div style={{textAlign: 'center'}}>
+              <p>Or click cancel to continue as a guest</p>
+              <Button onClick={closeModal}>Cancel</Button>
+            </div>
+          </Modal.Description>
+        </Modal.Content>
+      </Modal>
+    );
+  }
+}
+
+export default connect(null, actions)(UnauthModal);


### PR DESCRIPTION
# Why

- 未ログインユーザーが、ログイン済みユーザーしか遷移できない画面にアクセスした時の対応を入れる

# How

- Firestore のセキュリティルールは追加 
  - https://github.com/samuraikun/meetup_sns_react_app/pull/12 で対応済み
- `redux-auth-wrapper`を使用
  - HOCパターンを使用して、アクセスに認証が必要なコンポーネントに対して、適用させる
  - `redux-auth-wrapper`でラップされたコンポーネントは、ログインを促すポップアップを表示する
  - `react-router v4`と併用することを前提にしたAPIを提供している